### PR TITLE
Fix docs + wait

### DIFF
--- a/docs/examples/UserGuide/whale_ex.jl
+++ b/docs/examples/UserGuide/whale_ex.jl
@@ -31,7 +31,7 @@ provider = TileProviders.NASAGIBS(:ViirsEarthAtNight2012)
 
 set_theme!(theme_black())
 m = Tyler.Map(Rect2f(Rect2f(lomn - δlon/2, lamn-δlat/2, 2δlon, 2δlat)), 5;
-    provider, min_tiles=8, max_tiles=16)
+    provider, min_tiles=8, max_tiles=16, figure=Figure(resolution=(1000, 600)))
 wait(m)
 
 nt = 30
@@ -47,8 +47,6 @@ objline = lines!(m.axis, trail; color = trailcolor, linewidth=3)
 objscatter = scatter!(m.axis, whale; markersize = 15, color = :orangered,
     strokecolor=:grey90, strokewidth=1)
 hidedecorations!(m.axis)
-translate!(objline, 0, 0, 2)
-translate!(objscatter, 0, 0, 2)
 #limits!(ax, minimum(lon), maximum(lon), minimum(lat), maximum(lat))
 ## the animation is done by updating the Observable values
 ## change assets->(your folder) to make it work in your local env

--- a/src/Tyler.jl
+++ b/src/Tyler.jl
@@ -42,8 +42,17 @@ end
 
 # Wait for all tiles to be
 function Base.wait(map::Map)
-    while !isempty(map.tiles_being_added)
-        wait(last(first(map.tiles_being_added)))
+    while true
+        if !isempty(map.tiles_being_added)
+            wait(last(first(map.tiles_being_added)))
+        end
+        if !isempty(map.queued_but_not_downloaded)
+            sleep(0.001) # we don't have a task to wait on, so we sleep
+        end
+        # We're done if both are empty!
+        if isempty(map.tiles_being_added) && isempty(map.queued_but_not_downloaded)
+            return map
+        end
     end
 end
 
@@ -53,7 +62,7 @@ function Base.show(io::IO, m::MIME"image/png", map::Map)
     show(io, m, map.figure)
 end
 
-function Map(rect::Rect, zoom=3, input_cs = wgs84;
+function Map(rect::Rect, zoom=15, input_cs = wgs84;
         figure=Figure(resolution=(1500, 1500)),
         coordinate_system = MapTiles.web_mercator,
         provider=TileProviders.OpenStreetMap(:Mapnik),
@@ -61,13 +70,12 @@ function Map(rect::Rect, zoom=3, input_cs = wgs84;
         max_tiles=Makie.automatic,
         max_parallel_downloads = 16,
         cache_size_gb=5)
-    ext = extent(rect)
-    tiles = MapTiles.TileGrid(ext, zoom, input_cs)
+
     fetched_tiles = LRU{Tile, Matrix{RGB{N0f8}}}(; maxsize=cache_size_gb * 10^9, by=Base.sizeof)
     free_tiles = Makie.Combined[]
     tiles_being_added = ThreadSafeDict{Tile,Task}()
     downloaded_tiles = Channel{Tuple{Tile,TileImage}}(128)
-    screen = display(figure)
+    screen = display(figure; title="Tyler (with Makie)")
     if isnothing(screen)
         error("please load either GLMakie, WGLMakie or CairoMakie")
     end
@@ -80,6 +88,7 @@ function Map(rect::Rect, zoom=3, input_cs = wgs84;
     if !(max_tiles isa Int)
         max_tiles = nx * ny
     end
+    ext = Extents.extent(rect)
     ext_target = MapTiles.project_extent(ext, input_cs, coordinate_system)
     X = ext_target.X
     Y = ext_target.Y
@@ -88,7 +97,7 @@ function Map(rect::Rect, zoom=3, input_cs = wgs84;
     tyler = Map(
         provider, coordinate_system,
         min_tiles, max_tiles, Observable(zoom),
-        figure, axis, Set(tiles), plots, free_tiles,
+        figure, axis, Set{Tile}(), plots, free_tiles,
         fetched_tiles,
         max_parallel_downloads, Set{Tile}(),
         tiles_being_added, downloaded_tiles,
@@ -102,6 +111,8 @@ function Map(rect::Rect, zoom=3, input_cs = wgs84;
             end
             sleep(0.01)
         end
+        empty!(tyler.queued_but_not_downloaded)
+        empty!(tyler.displayed_tiles)
     end
     #
     display_task[] = @async begin
@@ -116,10 +127,11 @@ function Map(rect::Rect, zoom=3, input_cs = wgs84;
     end
 
     # Queue tiles to be downloaded & displayed
-    foreach(tile -> queue_tile!(tyler, tile), tiles)
+    update_tiles!(tyler, ext_target)
 
     on(axis.finallimits) do rect
-        update_tiles!(tyler, rect)
+        isopen(screen) || return
+        update_tiles!(tyler, Extents.extent(rect))
         return
     end
     return tyler
@@ -170,7 +182,7 @@ function place_tile!(tile::Tile, plot, coordinate_system)
     bounds = MapTiles.extent(tile, coordinate_system)
     xmin, xmax = bounds.X
     ymin, ymax = bounds.Y
-    translate!(plot, xmin, ymin, tile.z)
+    translate!(plot, xmin, ymin, tile.z - 100)
     scale!(plot, xmax - xmin, ymax - ymin, 0)
     return
 end
@@ -259,11 +271,11 @@ end
 max_zoom(tyler::Map) = Int(Providers.max_zoom(tyler.provider))
 min_zoom(tyler::Map) = Int(Providers.min_zoom(tyler.provider))
 
-function update_tiles!(tyler::Map, display_rect::Rect2)
+function update_tiles!(tyler::Map, area::Extent)
     min_tiles = tyler.min_tiles
     max_tiles = tyler.max_tiles
     new_tiles, new_zoom = get_tiles(
-        extent(display_rect),
+        area,
         tyler.coordinate_system,
         tyler.zoom[],
         min_zoom(tyler), max_zoom(tyler),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,7 @@ buildings = buildings_from_file("london_buildings.osm");
 
 # Default
 london = Rect2f(-0.0921, 51.5, 0.04, 0.025)
-m = Tyler.Map(london)
-
+m = wait(Tyler.Map(london)) # waits until all tiles are displayed
 # Nasa
 provider = TileProviders.NASAGIBS()
 m = Tyler.Map(Rect2f(0, 50, 40, 20), 5; provider=provider, min_tiles=8, max_tiles=32)


### PR DESCRIPTION
We broke wait and what tiles to load when creating a new `Tyler.Map`, which broke the docs, but also only started downloading resonable tiles once you start panning/zooming.
Also, I moved the map tiles to the back of the z-index range, so one doesn't need to translate plots over the map to the front anymore.
