### PR TITLE
use actual resolution after resizing

### DIFF
--- a/src/Tyler.jl
+++ b/src/Tyler.jl
@@ -264,7 +264,7 @@ TileProviders.max_zoom(tyler::Map) = Int(max_zoom(tyler.provider))
 TileProviders.min_zoom(tyler::Map) = Int(min_zoom(tyler.provider))
 
 function get_zoom(tyler::Map, area)
-    res = size(tyler.figure.scene) .* tyler.scale
+    res = size(tyler.axis.scene) .* tyler.scale
     clamp(z_index(area, (X=res[2], Y=res[1]), tyler.coordinate_system), min_zoom(tyler), max_zoom(tyler))
 end
 

--- a/src/Tyler.jl
+++ b/src/Tyler.jl
@@ -264,7 +264,7 @@ TileProviders.max_zoom(tyler::Map) = Int(max_zoom(tyler.provider))
 TileProviders.min_zoom(tyler::Map) = Int(min_zoom(tyler.provider))
 
 function get_zoom(tyler::Map, area)
-    res = tyler.figure.scene.theme.resolution.val .* tyler.scale
+    res = size(tyler.figure.scene) .* tyler.scale
     clamp(z_index(area, (X=res[2], Y=res[1]), tyler.coordinate_system), min_zoom(tyler), max_zoom(tyler))
 end
 
@@ -354,4 +354,3 @@ function debug_tiles!(map::Tyler.Map)
 end
 
 end
-


### PR DESCRIPTION
Noticed, that `get_zoom` was using the wrong `resolution`, and therefore everything got super blurry after resizing to a big window.
