### PR TITLE
Make max_zoom part of the struct

### DIFF
--- a/src/Tyler.jl
+++ b/src/Tyler.jl
@@ -125,7 +125,6 @@ function Map(extent, extent_crs=wgs84;
     ext_target = MapTiles.project_extent(extent, extent_crs, crs)
     X = ext_target.X
     Y = ext_target.Y
-    @show Y
     axis.autolimitaspect = 1
     Makie.limits!(axis, (X[1], X[2]), (Y[1], Y[2]))
 


### PR DESCRIPTION
This allows to set the maximal zoom level that is downloaded as a keyword argument during Map construction. This is useful, when the TileProvider has different zoom levels for different parts of the world. Using the max_zoom level of the provider would therefore lead to multiple download errors.

One example where this happens is the french Geoportail provider `TileProviders.GeoportailFrance(:orthos, apikey="choisirgeoportail")` which has a max_zoom level of 19 but these tiles are only available in France and in other parts of the world it is restricted to zoom level 12. 

I am not sure, whether we should also do this for min_zoom and how I could be testing that this is working.