### PR TITLE
Remove type piracy on extent and Rect2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ TileProviders = "263fe934-28e1-4ae9-998a-c2629c5fede6"
 
 [compat]
 julia = "1"
+GeometryBasics = "0.4.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Tyler.jl
+++ b/src/Tyler.jl
@@ -279,10 +279,6 @@ function queue_tile!(tyler::Map, tile)
     end
 end
 
-function Extents.extent(rect::Rect2)
-    (xmin, ymin), (xmax, ymax) = extrema(rect)
-    return Extent(X=(xmin, xmax), Y=(ymin, ymax))
-end
 
 TileProviders.max_zoom(tyler::Map) = Int(max_zoom(tyler.provider))
 TileProviders.min_zoom(tyler::Map) = Int(min_zoom(tyler.provider))


### PR DESCRIPTION
This functionality lives now in GeometryBasics https://github.com/JuliaGeometry/GeometryBasics.jl/pull/196
