### PR TITLE
Fix typo on main doc page

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ hero:
 features:
   - title: TileProviders
     details: A large collection of tile providers.
-  - title: Makie intergration
+  - title: Makie integration
     details: Well integrated with the Makie ecosystem.
 ---
 ```


### PR DESCRIPTION
Minor typo that has been bugging me.

intergration -> integration