### PR TITLE
[WIP] Activate GeoAxis Maps using a GeoMakie extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 ThreadSafeDicts = "4239201d-c60e-5e0a-9702-85d713665ba7"
 TileProviders = "263fe934-28e1-4ae9-998a-c2629c5fede6"
 
+[weakdeps]
+GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
+
 [compat]
 ArchGDAL = "0.10"
 Colors = "0.12, 0.13"
@@ -35,6 +38,7 @@ Extents = "0.1.2"
 FileIO = "1"
 GeoFormatTypes = "0.4"
 GeoInterface = "1"
+GeoMakie = "0.7.9"
 GeometryBasics = "0.4, 0.5"
 GeometryOps = "0.1"
 HTTP = "1"

--- a/ext/TylerGeoMakieExt/TylerGeoMakieExt.jl
+++ b/ext/TylerGeoMakieExt/TylerGeoMakieExt.jl
@@ -1,0 +1,107 @@
+using Tyler, GeoMakie
+
+using LinearAlgebra, OrderedCollections
+
+import Tyler: tile_reloader, create_tileplot!, update_tile_plot!,
+            Map, AbstractMap, ImageData, PlotConfig, SimpleTiling, Halo2DTiling
+
+using Tyler: to_rect
+
+
+using Makie
+
+using Makie: AbstractAxis, Mat
+
+# functions directly related to plotting
+
+function Tyler.create_tileplot!(config::PlotConfig, axis::GeoAxis, data::ImageData, bounds::Rect, tile_crs)
+    mini, maxi = extrema(bounds)
+    plot = GeoMakie.meshimage!(
+        axis,
+        (mini[1], maxi[1]), (mini[2], maxi[2]), data;
+        uv_transform=:rotl90,
+        inspectable=false,
+        reset_limits=false, # substitute for plotting directly to scene, since GeoMakie handles the CRS stuff
+        source = tile_crs[2], # tile_crs is a tuple of (tile, crs), we can pass the CRS directly to GeoMakie though
+        config.attributes...
+    )
+    return plot
+end
+
+function Tyler.update_tile_plot!(plot::GeoMakie.MeshImage, ::PlotConfig, axis::AbstractAxis, data::ImageData, bounds::Rect, tile_crs)
+    mini, maxi = extrema(bounds)
+    plot[1] = (mini[1], maxi[1])
+    plot[2] = (mini[2], maxi[2])
+    plot[3] = data
+    return
+end
+
+
+# functions related to fetching tiles
+
+function Tyler.tile_reloader(m::Map{GeoAxis})
+    axis = m.axis
+    throttled = Makie.Observables.throttle(0.2, axis.finallimits)
+    map_inverse_transform = lift(axis.scene, axis.dest) do dest
+        GeoMakie.create_transform(#= destination =# m.crs, #= source =# dest)
+    end
+
+    onany(axis.scene, map_inverse_transform, throttled; update=true) do ax2map, axis_finallimits
+        new_extent = Makie.apply_transform(ax2map, axis_finallimits)
+        Tyler.update_tiles!(m, new_extent)
+        return
+    end
+end
+
+
+# Here, the `area` has already been transformed to the tile CRS
+function Tyler.get_tiles_for_area(m::Map{GeoAxis}, scheme::Halo2DTiling, area::Union{Rect,Extent})
+    area = typeof(area) <: Rect ? Extents.extent(area) : area
+    # `depth` determines the number of layers below the current
+    # layer to load. Tiles are downloaded in order from lowest to highest zoom.
+    depth = scheme.depth
+
+    # Calculate the zoom level
+    # TODO, also early return if too many tiles to plot?
+    ideal_zoom, zoom, approx_ntiles = Tyler.optimal_zoom(m, norm(widths(to_rect(area))))
+    m.zoom[] = zoom
+
+    # And the z layers we will plot
+    layer_range = max(Tyler.min_zoom(m), zoom - depth):zoom
+    # Get the tiles around the mouse first
+    xpos, ypos = Makie.mouseposition(m.axis.scene)
+    # transform the mouse position to tile CRS
+    # TODO: we should instead transform areas after they are calculated in the axis's CRS
+    xpos, ypos = Makie.apply_transform(GeoMakie.create_transform(m.crs, m.axis.dest[]), Point2f(xpos, ypos))
+    xspan = (area.X[2] - area.X[1]) * 0.01
+    yspan = (area.Y[2] - area.Y[1]) * 0.01
+    mouse_area = Extents.Extent(; X=(xpos - xspan, xpos + xspan), Y=(ypos - yspan, ypos + yspan))
+    # Make a halo around the mouse tile to load next, intersecting area so we don't download outside the plot
+    mouse_halo_area = Tyler.grow_extent(mouse_area, 10)
+    # Define a halo around the area to download last, so pan/zoom are filled already
+    halo_area = Tyler.grow_extent(area, scheme.halo) # We don't mind that the middle tiles are the same, the OrderedSet will remove them
+
+    # transform the areas to tile crs
+
+    # Define all the tiles in the order they will load in
+    background_areas = if Extents.intersects(mouse_halo_area, area)
+        mha = Extents.intersection(mouse_halo_area, area)
+        if Extents.intersects(mouse_area, area)
+            [Extents.intersection(mouse_area, area), mha, halo_area]
+        else
+            [mha, halo_area]
+        end
+    else
+        [halo_area]
+    end
+
+    foreground = OrderedSet{Tile}(MapTiles.TileGrid(area, zoom, m.crs))
+    background = OrderedSet{Tile}()
+    for z in layer_range
+        z == zoom && continue
+        for ext in background_areas
+            union!(background, MapTiles.TileGrid(ext, z, m.crs))
+        end
+    end
+    return foreground, background
+end


### PR DESCRIPTION
This is all fairly generic / public ish API, so I'm happy to have this live in Tyler.

This works very well for static maps. But when scrolling in and out, after some point I will always see this error:

```
julia> Error in callback:
StackOverflowError:
julia> ┌ Warning: Error while fetching tile on thread 1
│   exception =
│    RequestError: HTTP/1.1 302 Found (Operation timed out after 4999 milliseconds with 0 bytes received) while requesting https://map1.vis.earthdata.nasa.gov/wmts-webmerc/VIIRS_CityLights_2012/default//GoogleMapsCompatible_Level8/7/49/31.jpg
│    Stacktrace:
│      [1] (::Downloads.var"#9#19"{IOBuffer, Base.DevNull, Nothing, Vector{Pair{String, String}}, Float64, Nothing, Bool, Nothing, Bool, Nothing, String, Bool, Bool})(easy::Downloads.Curl.Easy)
│        @ Downloads ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:452
│      [2] with_handle(f::Downloads.var"#9#19"{IOBuffer, Base.DevNull, Nothing, Vector{Pair{String, String}}, Float64, Nothing, Bool, Nothing, Bool, Nothing, String, Bool, Bool}, handle::Downloads.Curl.Easy)
│        @ Downloads.Curl ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Curl/Curl.jl:105
│      [3] #8
│        @ ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:363 [inlined]
│      [4] arg_write(f::Downloads.var"#8#18"{Base.DevNull, Nothing, Vector{Pair{String, String}}, Float64, Nothing, Bool, Nothing, Bool, Nothing, String, Bool, Bool}, arg::IOBuffer)
│        @ ArgTools ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/ArgTools/src/ArgTools.jl:134
│      [5] #7
│        @ ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:362 [inlined]
│      [6] arg_read
│        @ ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/ArgTools/src/ArgTools.jl:76 [inlined]
│      [7] request(url::String; input::Nothing, output::IOBuffer, method::Nothing, headers::Vector{Pair{String, String}}, timeout::Float64, progress::Nothing, verbose::Bool, debug::Nothing, throw::Bool, downloader::Downloads.Downloader, interrupt::Nothing)
│        @ Downloads ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:361
│      [8] request
│        @ ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:328 [inlined]
│      [9] #3
│        @ ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:259 [inlined]
│     [10] arg_write(f::Downloads.var"#3#4"{Nothing, Vector{Pair{String, String}}, Float64, Nothing, Bool, Nothing, Downloads.Downloader, String}, arg::IOBuffer)
│        @ ArgTools ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/ArgTools/src/ArgTools.jl:134
│     [11] #download#2
│        @ ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:258 [inlined]
│     [12] download
│        @ ~/.julia/juliaup/julia-1.11.1+0.x64.apple.darwin14/share/julia/stdlib/v1.11/Downloads/src/Downloads.jl:247 [inlined]
│     [13] download_tile_data(dl::Tyler.ByteDownloader, provider::Provider, url::String)
│        @ Tyler ~/.julia/dev/Tyler/src/downloader.jl:20
│     [14] fetch_tile
│        @ ~/.julia/dev/Tyler/src/tiles.jl:101 [inlined]
│     [15] (::Tyler.var"#6#7"{Tyler.ByteDownloader, Provider, Tile})()
│        @ Tyler ~/.julia/dev/Tyler/src/tiles.jl:48
│     [16] get!(default::Tyler.var"#6#7"{Tyler.ByteDownloader, Provider, Tile}, lru::LRUCache.LRU{String, Union{Nothing, Matrix{RGB{FixedPointNumbers.N0f8}}}}, key::String)
│        @ LRUCache ~/.julia/packages/LRUCache/ctUcD/src/LRUCache.jl:169
│     [17] run_loop(dl::Tyler.ByteDownloader, tile_queue::Channel{Tile}, fetched_tiles::LRUCache.LRU{String, Union{Nothing, Matrix{RGB{FixedPointNumbers.N0f8}}}}, provider::Provider, downloaded_tiles::Channel{Tuple{Tile, Union{Nothing, Matrix{RGB{FixedPointNumbers.N0f8}}}}})
│        @ Tyler ~/.julia/dev/Tyler/src/tiles.jl:46
│     [18] (::Tyler.var"#10#13"{Provider, Channel{Tile}, Channel{Tuple{Tile, Union{Nothing, Matrix{RGB{FixedPointNumbers.N0f8}}}}}, LRUCache.LRU{String, Union{Nothing, Matrix{RGB{FixedPointNumbers.N0f8}}}}, Tyler.ByteDownloader})()
│        @ Tyler ~/.julia/dev/Tyler/src/tiles.jl:90
└ @ Tyler ~/.julia/dev/Tyler/src/tiles.jl:61


     [1] invokelatest(::Any, ::Any, ::Vararg{Any})
       @
julia> 

     [2] (::Observables.OnAny)(value::Any)

julia> Observables.jl:420

     [3] #invokelatest#2

julia> ./essentials.jl:1055 [inlined]
     [4] invokelatest
       @ ./essentials.jl:1052 [inlined]
     [5] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
     [6] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
     [7] (::Observables.SetindexCallback)(x::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:148
     [8] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
     [9] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [10] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [11] (::GeoMakie.var"#38#53"{Observable{Vector{GeometryBasics.Point{2, Float64}}}, Observable{Vector{String}}})(spine::Vector{@NamedTuple{input::GeometryBasics.Point{2, Float64}, projected::GeometryBasics.Point{2, Float64}, dir::GeometryBasics.Point{2, Float64}, intersect_dir::GeometryBasics.Point{2, Float64}}}, offset::Float64, size::Float64)
       @ GeoMakie ~/.julia/dev/GeoMakie/src/geoaxis.jl:670
    [12] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
    [13] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
    [14] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
    [15] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
    [16] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [17] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [18] setindex!
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123 [inlined]
    [19] (::GeoMakie.var"#34#46"{Observable{Vector{@NamedTuple{input::GeometryBasics.Point{2, Float64}, projected::GeometryBasics.Point{2, Float64}, dir::GeometryBasics.Point{2, Float64}, intersect_dir::GeometryBasics.Point{2, Float64}}}}, Observable{Vector{@NamedTuple{input::GeometryBasics.Point{2, Float64}, projected::GeometryBasics.Point{2, Float64}, dir::GeometryBasics.Point{2, Float64}, intersect_dir::GeometryBasics.Point{2, Float64}}}}, Camera})(spines::GeoMakie.Spines, pv::StaticArraysCore.SMatrix{4, 4, Float64, 16}, area::GeometryBasics.HyperRectangle{2, Int64})
       @ GeoMakie ~/.julia/dev/GeoMakie/src/geoaxis.jl:652
    [20] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
    [21] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
    [22] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
    [23] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
    [24] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [25] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [26] (::GeoMakie.var"#33#45"{GeoAxis, Observable{GeoMakie.Spines}, Observable{Vector{GeometryBasics.Point{2, Float64}}}, Observable{Vector{GeometryBasics.Point{2, Float64}}}, Observable{Any}})(user_xticks::MakieCore.Automatic, user_yticks::MakieCore.Automatic, trans::Proj.Transformation, fl::GeometryBasics.HyperRectangle{2, Float64}, vp::GeometryBasics.HyperRectangle{2, Int64})
       @ GeoMakie ~/.julia/dev/GeoMakie/src/geoaxis.jl:603
    [27] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
    [28] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
    [29] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
    [30] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
    [31] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [32] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [33] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
    [34] (::Observables.MapCallback)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:436
--- the above 5 lines are repeated 1 more time ---
    [40] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
    [41] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [42] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [43] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
    [44] update_computedbbox!(computedbbox::Observable{GeometryBasics.HyperRectangle{2, Float32}}, suggestedbbox::GeometryBasics.HyperRectangle{2, Float32}, alignment::Tuple{Float32, Float32}, reporteddimensions::GridLayoutBase.Dimensions, alignmode::Inside, protrusions::GridLayoutBase.RectSides{Float32}, sizeattrs::Observable{Tuple{Union{Nothing, Float32, Auto, Fixed, Relative}, Union{Nothing, Float32, Auto, Fixed, Relative}}}, autosizeobservable::Observable{Tuple{Union{Nothing, Float32}, Union{Nothing, Float32}}})
       @ GridLayoutBase ~/.julia/packages/GridLayoutBase/xvxWi/src/layoutobservables.jl:356
    [45] (::GridLayoutBase.var"#106#108"{Observable{GridLayoutBase.Dimensions}, Observable{Tuple{Union{Nothing, Float32, Auto, Fixed, Relative}, Union{Nothing, Float32, Auto, Fixed, Relative}}}, Observable{Tuple{Union{Nothing, Float32}, Union{Nothing, Float32}}}, Observable{Any}, Observable{GridLayoutBase.RectSides{Float32}}, Observable{GeometryBasics.HyperRectangle{2, Float32}}})(sbbox::GeometryBasics.HyperRectangle{2, Float32}, ali::Tuple{Float32, Float32})
       @ GridLayoutBase ~/.julia/packages/GridLayoutBase/xvxWi/src/layoutobservables.jl:218
    [46] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
    [47] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
    [48] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
    [49] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
    [50] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [51] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [52] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
    [53] align_to_bbox!(gl::GridLayout, suggestedbbox::GeometryBasics.HyperRectangle{2, Float32})
       @ GridLayoutBase ~/.julia/packages/GridLayoutBase/xvxWi/src/gridlayout.jl:1096
    [54] (::GridLayoutBase.var"#11#12"{GridLayout})(bbox::GeometryBasics.HyperRectangle{2, Float32})
       @ GridLayoutBase ~/.julia/packages/GridLayoutBase/xvxWi/src/gridlayout.jl:158
    [55] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
    [56] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [57] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [58] update!(gl::GridLayout)
       @ GridLayoutBase ~/.julia/packages/GridLayoutBase/xvxWi/src/gridlayout.jl:193
    [59] update!
       @ ~/.julia/packages/GridLayoutBase/xvxWi/src/gridlayout.jl:1525 [inlined]
    [60] (::GridLayoutBase.var"#14#15"{GridLayoutBase.GridContent{GridLayout}, GeoAxis})(c::GridLayoutBase.Dimensions)
       @ GridLayoutBase ~/.julia/packages/GridLayoutBase/xvxWi/src/gridlayout.jl:261
    [61] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
    [62] invokelatest
       @ ./essentials.jl:1052 [inlined]
    [63] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
    [64] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
    [65] (::Observables.MapCallback)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:436
--- the above 5 lines are repeated 2 more times ---
--- the above 68 lines are repeated 366 more times ---
 [24964] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [24965] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [24966] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [24967] (::GeoMakie.var"#38#53"{Observable{Vector{GeometryBasics.Point{2, Float64}}}, Observable{Vector{String}}})(spine::Vector{@NamedTuple{input::GeometryBasics.Point{2, Float64}, projected::GeometryBasics.Point{2, Float64}, dir::GeometryBasics.Point{2, Float64}, intersect_dir::GeometryBasics.Point{2, Float64}}}, offset::Float64, size::Float64)
       @ GeoMakie ~/.julia/dev/GeoMakie/src/geoaxis.jl:670
 [24968] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
 [24969] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
 [24970] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
 [24971] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [24972] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [24973] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [24974] setindex!
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123 [inlined]
 [24975] (::GeoMakie.var"#34#46"{Observable{Vector{@NamedTuple{input::GeometryBasics.Point{2, Float64}, projected::GeometryBasics.Point{2, Float64}, dir::GeometryBasics.Point{2, Float64}, intersect_dir::GeometryBasics.Point{2, Float64}}}}, Observable{Vector{@NamedTuple{input::GeometryBasics.Point{2, Float64}, projected::GeometryBasics.Point{2, Float64}, dir::GeometryBasics.Point{2, Float64}, intersect_dir::GeometryBasics.Point{2, Float64}}}}, Camera})(spines::GeoMakie.Spines, pv::StaticArraysCore.SMatrix{4, 4, Float64, 16}, area::GeometryBasics.HyperRectangle{2, Int64})
       @ GeoMakie ~/.julia/dev/GeoMakie/src/geoaxis.jl:652
 [24976] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
 [24977] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
 [24978] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
 [24979] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [24980] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [24981] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [24982] (::GeoMakie.var"#33#45"{GeoAxis, Observable{GeoMakie.Spines}, Observable{Vector{GeometryBasics.Point{2, Float64}}}, Observable{Vector{GeometryBasics.Point{2, Float64}}}, Observable{Any}})(user_xticks::MakieCore.Automatic, user_yticks::MakieCore.Automatic, trans::Proj.Transformation, fl::GeometryBasics.HyperRectangle{2, Float64}, vp::GeometryBasics.HyperRectangle{2, Int64})
       @ GeoMakie ~/.julia/dev/GeoMakie/src/geoaxis.jl:603
 [24983] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
 [24984] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
 [24985] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
 [24986] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [24987] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [24988] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [24989] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
 [24990] (::Observables.MapCallback)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:436
 [24991] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [24992] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [24993] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [24994] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
 [24995] adjustlimits!(la::GeoAxis)
       @ Makie ~/.julia/dev/Makie/src/makielayout/blocks/axis.jl:990
 [24996] (::GeoMakie.var"#60#63"{GeoAxis})(::GeometryBasics.HyperRectangle{2, Int64}, ::GeometryBasics.HyperRectangle{2, Float64})
       @ GeoMakie ~/.julia/dev/GeoMakie/src/makie-axis.jl:32
 [24997] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
 [24998] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
 [24999] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
 [25000] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [25001] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [25002] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [25003] setindex!(observable::Observable, val::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123
 [25004] process_interaction(s::Makie.ScrollZoom, event::ScrollEvent, ax::GeoAxis)
       @ GeoMakie ~/.julia/dev/GeoMakie/src/makie-axis.jl:456
 [25005] process_axis_event(ax::GeoAxis, event::ScrollEvent)
       @ Makie ~/.julia/dev/Makie/src/makielayout/blocks/axis.jl:15
 [25006] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::@Kwargs{})
       @ Base ./essentials.jl:1055
 [25007] invokelatest(::Any, ::Any, ::Vararg{Any})
       @ Base ./essentials.jl:1052
 [25008] (::Observables.OnAny)(value::Any)
       @ Observables ~/.julia/packages/Observables/YdEbO/src/Observables.jl:420
 [25009] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [25010] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [25011] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [25012] setindex!
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123 [inlined]
 [25013] (::Makie.var"#1640#1642"{Scene, Observable{ScrollEvent}})(s::Tuple{Float64, Float64})
       @ Makie ~/.julia/dev/Makie/src/makielayout/blocks/axis.jl:33
 [25014] #invokelatest#2
       @ ./essentials.jl:1055 [inlined]
 [25015] invokelatest
       @ ./essentials.jl:1052 [inlined]
 [25016] notify
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:206 [inlined]
 [25017] setindex!
       @ ~/.julia/packages/Observables/YdEbO/src/Observables.jl:123 [inlined]
 [25018] (::GLMakie.ScrollUpdater)(window::GLFW.Window, w::Float64, h::Float64)
       @ GLMakie ~/.julia/dev/Makie/GLMakie/src/events.jl:241
 [25019] _ScrollCallbackWrapper(window::GLFW.Window, xoffset::Float64, yoffset::Float64)
       @ GLFW ~/.julia/packages/GLFW/wmoTL/src/callback.jl:43
 [25020] PollEvents
       @ ~/.julia/packages/GLFW/wmoTL/src/glfw3.jl:702 [inlined]
 [25021] pollevents(screen::GLMakie.Screen{GLFW.Window}, frame_state::Makie.TickState)
       @ GLMakie ~/.julia/dev/Makie/GLMakie/src/screen.jl:485
 [25022] on_demand_renderloop(screen::GLMakie.Screen{GLFW.Window})
       @ GLMakie ~/.julia/dev/Makie/GLMakie/src/screen.jl:935
 [25023] renderloop(screen::GLMakie.Screen{GLFW.Window})
       @ GLMakie ~/.julia/dev/Makie/GLMakie/src/screen.jl:963
```