### PR TITLE
Allow axes to be constructed by namedtuple syntax in Map

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -95,7 +95,7 @@ function setup_figure_and_axis!(figure::GridPosition, axis, ext_target, crs)
     """)
 end
 
-function setup_figure_and_axis!(gridposition::GridPosition, axis::NamedTuple, ext_target, crs)
+function setup_figure_and_axis!(gridposition::GridPosition, axis_kws_nt::NamedTuple, ext_target, crs)
     figure = _get_parent_figure(gridposition)
 
     axis_kws = Dict(pairs(axis_kws_nt))
@@ -173,7 +173,7 @@ end
 function Map(extent, extent_crs=wgs84;
     size=(1000, 1000),
     figure=Makie.Figure(; size=size),
-    axis=Makie.Axis(figure[1, 1]; aspect=Makie.DataAspect()),
+    axis=(; type = Axis, aspect = DataAspect()),
     plot_config=PlotConfig(),
     provider=TileProviders.OpenStreetMap(:Mapnik),
     crs=MapTiles.web_mercator,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,16 +40,18 @@ end
 
 @testset "NamedTuple axis syntax" begin
     b = Rect2f(-20.0, -20.0, 40.0, 40.0)
-    m = @test_nowarn Tyler.Map(b, provider=Tyler.TileProviders.OpenStreetMap(), axis = (; type = Axis, aspect = AxisAspect(1)))
-    @test only(contents(m.figure.layout[1, 1])) isa Axis
-    @test only(contents(m.figure.layout[1, 1])).aspect[] == AxisAspect(1)
+    m1 = @test_nowarn Tyler.Map(b, provider=Tyler.TileProviders.OpenStreetMap(), axis = (; type = Axis, aspect = AxisAspect(1)))
+    @test only(contents(m1.figure.layout[1, 1])) isa Axis
+    @test only(contents(m1.figure.layout[1, 1])).aspect[] == AxisAspect(1)
+    close(m1)
 end
 
 @testset "Pass GridPosition to figure kwarg" begin
     b = Rect2f(-20.0, -20.0, 40.0, 40.0)
     f = Figure()
-    m = @test_nowarn Tyler.Map(b, figure = f[1, 2])
-    @test only(contents(m.figure.layout[1, 2])) isa Axis
+    m1 = @test_nowarn Tyler.Map(b, figure = f[1, 2])
+    @test only(contents(m1.figure.layout[1, 2])) isa Axis
+    close(m1)
 end
 
 # Reference tests?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ end
 
 @testset "Pass GridPosition to figure kwarg" begin
     f = Figure()
-    m = @test_nowarn Tyler.Map(b, provider = OpenStreetMap(), figure = f[1, 2])
+    m = @test_nowarn Tyler.Map(b, figure = f[1, 2])
     @test only(contents(m.figure.layout[1, 2])) isa Axis
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ end
 
 @testset "NamedTuple axis syntax" begin
     b = Rect2f(-20.0, -20.0, 40.0, 40.0)
-    m = @test_nowarn Tyler.Map(b, provider=OpenStreetMap(), axis = (; type = Axis, aspect = AxisAspect(1)))
+    m = @test_nowarn Tyler.Map(b, provider=Tyler.TileProviders.OpenStreetMap(), axis = (; type = Axis, aspect = AxisAspect(1)))
     @test only(contents(m.figure.layout[1, 1])) isa Axis
     @test only(contents(m.figure.layout[1, 1])).aspect == AxisAspect(1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ end
     b = Rect2f(-20.0, -20.0, 40.0, 40.0)
     m = @test_nowarn Tyler.Map(b, provider=Tyler.TileProviders.OpenStreetMap(), axis = (; type = Axis, aspect = AxisAspect(1)))
     @test only(contents(m.figure.layout[1, 1])) isa Axis
-    @test only(contents(m.figure.layout[1, 1])).aspect == AxisAspect(1)
+    @test only(contents(m.figure.layout[1, 1])).aspect[] == AxisAspect(1)
 end
 
 @testset "Pass GridPosition to figure kwarg" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,19 @@ display(m)
     @test GeoInterface.crs(m) == Tyler.MapTiles.WebMercator()
 end
 
+@testset "NamedTuple axis syntax" begin
+    b = Rect2f(-20.0, -20.0, 40.0, 40.0)
+    m = @test_nowarn Tyler.Map(b, provider=OpenStreetMap(), axis = (; type = Axis, aspect = AxisAspect(1)))
+    @test only(contents(m.figure.layout[1, 1])) isa Axis
+    @test only(contents(m.figure.layout[1, 1])).aspect == AxisAspect(1)
+end
+
+@testset "Pass GridPosition to figure kwarg" begin
+    f = Figure()
+    m = @test_nowarn Tyler.Map(b, provider = OpenStreetMap(), figure = f[1, 2])
+    @test only(contents(m.figure.layout[1, 2])) isa Axis
+end
+
 # Reference tests?
 # provider = TileProviders.NASAGIBS()
 # m = Tyler.Map(Rect2f(0, 50, 40, 20), 5; provider=provider, min_tiles=8, max_tiles=32)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ end
 end
 
 @testset "Pass GridPosition to figure kwarg" begin
+    b = Rect2f(-20.0, -20.0, 40.0, 40.0)
     f = Figure()
     m = @test_nowarn Tyler.Map(b, figure = f[1, 2])
     @test only(contents(m.figure.layout[1, 2])) isa Axis


### PR DESCRIPTION
Allows 

```julia
b = Rect2f(-20.0, -20.0, 40.0, 40.0)
m = Tyler.Map(b, provider=OpenStreetMap(), axis = (; type = GeoAxis))

f = Figure()
m = Tyler.Map(b, provider = OpenStreetMap(), figure = f[1, 2])
```