### PR TITLE
Send an identifying User-Agent with tile requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Send a `User-Agent` header identifying Tyler and its version with every tile request, instead of the generic `curl/x.y julia/x.y` default that tile servers such as OpenStreetMap block [#170](https://github.com/MakieOrg/Tyler.jl/issues/170).
+  - Applications built on Tyler should identify themselves by setting `Tyler.USER_AGENT[]`, or per downloader via the `user_agent` keyword of `ByteDownloader`/`PathDownloader`.
+
 # v0.2.1
 
 - Allow creating `Map`s on `GeoAxis` (from GeoMakie) via a package extension [#114](https://github.com/MakieOrg/Tyler.jl/pull/114).

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -67,6 +67,29 @@ For some providers additional configuration steps are necessary, look at the `Ti
 
 :::
 
+## Identifying your application
+
+Tile servers use the `User-Agent` header of a request to tell their users apart, and several
+of them block traffic that does not identify itself - the [OSM Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/)
+is the best known example. Tyler therefore names itself and its version in every request it
+makes, e.g. `Tyler.jl/0.2.6 (+https://github.com/MakieOrg/Tyler.jl)`.
+
+If you build an application on top of Tyler, identify that application instead, ideally
+together with a way of contacting you:
+
+```julia
+using Tyler
+Tyler.USER_AGENT[] = "MyTownMaps/1.4 (+https://mytownmaps.example.com; maps@example.com)"
+```
+
+::: info
+
+Set this before creating a `Map`, since downloaders read `Tyler.USER_AGENT[]` when they are
+created. A single downloader can also be identified separately, via the `user_agent` keyword
+of `Tyler.ByteDownloader` and `Tyler.PathDownloader`.
+
+:::
+
 ## Figure size & aspect ratio
 
 Although, the figure size can be controlled by passing additional arguments to `Map`, it's better to define a Figure first and then continue with a normal Makie's figure creation workflow, namely

--- a/src/Tyler.jl
+++ b/src/Tyler.jl
@@ -34,6 +34,7 @@ const CACHE_PATH = Ref("")
 function __init__()
     # Initialize at init for relocatability
     CACHE_PATH[] = @get_scratch!("download-cache")
+    USER_AGENT[] = default_user_agent()
 end
 
 abstract type AbstractPlotConfig end

--- a/src/downloader.jl
+++ b/src/downloader.jl
@@ -1,22 +1,59 @@
 
 abstract type AbstractDownloader end
 
+"""
+    Tyler.USER_AGENT[]
+
+The `User-Agent` header Tyler sends with every tile request, by default
+`"Tyler.jl/\$(Base.pkgversion(Tyler)) (+https://github.com/MakieOrg/Tyler.jl)"`.
+
+Tile servers use this header to tell their users apart, and some of them - notably
+[OpenStreetMap](https://operations.osmfoundation.org/policies/tiles/) - block requests
+that carry the generic default of the underlying HTTP client instead.
+
+If you build an application on top of Tyler, identify that application here, ideally
+together with a way of contacting you:
+
+```julia
+Tyler.USER_AGENT[] = "MyTownMaps/1.4 (+https://mytownmaps.example.com; maps@example.com)"
+```
+
+Set this before constructing a `Map`, since downloaders read it when they are created.
+Individual downloaders can also be given a `user_agent` keyword, see
+[`ByteDownloader`](@ref) and [`PathDownloader`](@ref).
+"""
+const USER_AGENT = Ref{String}("")
+
+default_user_agent() = "Tyler.jl/$(something(Base.pkgversion(Tyler), "unknown")) (+https://github.com/MakieOrg/Tyler.jl)"
+
+# Downloads.jl otherwise identifies us as `curl/x.y julia/x.y`, which tile servers block,
+# so every request carries these headers. Kept per downloader to avoid reallocating them
+# for each tile.
+request_headers(user_agent::AbstractString) = ["User-Agent" => String(user_agent)]
+
 struct NoDownload <: AbstractDownloader end
 
+"""
+    ByteDownloader(timeout=3; user_agent=Tyler.USER_AGENT[])
+
+Downloads tiles into memory, identifying itself to the tile server as `user_agent`
+(see [`Tyler.USER_AGENT`](@ref)).
+"""
 struct ByteDownloader <: AbstractDownloader
     timeout::Float64
     downloader::Downloads.Downloader
     io::IOBuffer
     bytes::Vector{UInt8}
+    headers::Vector{Pair{String,String}}
 end
-function ByteDownloader(timeout=3)
+function ByteDownloader(timeout=3; user_agent=USER_AGENT[])
     downloader = Downloads.Downloader()
     downloader.easy_hook = (easy, info) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, timeout)
-    return ByteDownloader(timeout, downloader, IOBuffer(), UInt8[])
+    return ByteDownloader(timeout, downloader, IOBuffer(), UInt8[], request_headers(user_agent))
 end
 
 function download_tile_data(dl::ByteDownloader, provider, url)
-    Downloads.download(url, dl.io; downloader=dl.downloader, timeout=dl.timeout)
+    Downloads.download(url, dl.io; downloader=dl.downloader, timeout=dl.timeout, headers=dl.headers)
     # a bit of shananigans to allocate less and stress the GC less!
     resize!(dl.bytes, dl.io.ptr - 1)
     copyto!(dl.bytes, 1, dl.io.data, 1, dl.io.ptr-1)
@@ -24,25 +61,32 @@ function download_tile_data(dl::ByteDownloader, provider, url)
     return dl.bytes
 end
 
+"""
+    PathDownloader(cache_dir; timeout=5, cache_size_gb=5, user_agent=Tyler.USER_AGENT[])
+
+Downloads tiles into `cache_dir`, identifying itself to the tile server as `user_agent`
+(see [`Tyler.USER_AGENT`](@ref)).
+"""
 struct PathDownloader <: AbstractDownloader
     timeout::Float64
     downloader::Downloads.Downloader
     cache_dir::String
     lru::LRU{String, Int}
+    headers::Vector{Pair{String,String}}
 end
-function PathDownloader(cache_dir; timeout=5, cache_size_gb=5)
+function PathDownloader(cache_dir; timeout=5, cache_size_gb=5, user_agent=USER_AGENT[])
     isdir(cache_dir) || mkpath(cache_dir)
     lru = LRU{String, Int}(maxsize=cache_size_gb * 10^9, by=identity)
     downloader = Downloads.Downloader()
     downloader.easy_hook = (easy, info) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, timeout)
-    return PathDownloader(timeout, downloader, cache_dir, lru)
+    return PathDownloader(timeout, downloader, cache_dir, lru, request_headers(user_agent))
 end
 
 function download_tile_data(dl::PathDownloader, provider::AbstractProvider, url)
     unique_name = _unique_filename(url)
     path = joinpath(dl.cache_dir, unique_name * file_ending(provider))
     if !isfile(path)
-        Downloads.download(url, path; downloader=dl.downloader)
+        Downloads.download(url, path; downloader=dl.downloader, headers=dl.headers)
     end
     return path
 end

--- a/src/downloader.jl
+++ b/src/downloader.jl
@@ -26,11 +26,6 @@ const USER_AGENT = Ref{String}("")
 
 default_user_agent() = "Tyler.jl/$(something(Base.pkgversion(Tyler), "unknown")) (+https://github.com/MakieOrg/Tyler.jl)"
 
-# Downloads.jl otherwise identifies us as `curl/x.y julia/x.y`, which tile servers block,
-# so every request carries these headers. Kept per downloader to avoid reallocating them
-# for each tile.
-request_headers(user_agent::AbstractString) = ["User-Agent" => String(user_agent)]
-
 struct NoDownload <: AbstractDownloader end
 
 """
@@ -44,12 +39,15 @@ struct ByteDownloader <: AbstractDownloader
     downloader::Downloads.Downloader
     io::IOBuffer
     bytes::Vector{UInt8}
+    # The user agent goes out as a header instead of via CURLOPT_USERAGENT in the easy_hook
+    # below, since Downloads.jl adds its own `curl/x.y julia/x.y` header whenever we pass
+    # none, and a header beats that option.
     headers::Vector{Pair{String,String}}
 end
 function ByteDownloader(timeout=3; user_agent=USER_AGENT[])
     downloader = Downloads.Downloader()
     downloader.easy_hook = (easy, info) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, timeout)
-    return ByteDownloader(timeout, downloader, IOBuffer(), UInt8[], request_headers(user_agent))
+    return ByteDownloader(timeout, downloader, IOBuffer(), UInt8[], ["User-Agent" => user_agent])
 end
 
 function download_tile_data(dl::ByteDownloader, provider, url)
@@ -79,7 +77,7 @@ function PathDownloader(cache_dir; timeout=5, cache_size_gb=5, user_agent=USER_A
     lru = LRU{String, Int}(maxsize=cache_size_gb * 10^9, by=identity)
     downloader = Downloads.Downloader()
     downloader.easy_hook = (easy, info) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, timeout)
-    return PathDownloader(timeout, downloader, cache_dir, lru, request_headers(user_agent))
+    return PathDownloader(timeout, downloader, cache_dir, lru, ["User-Agent" => user_agent])
 end
 
 function download_tile_data(dl::PathDownloader, provider::AbstractProvider, url)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,4 +2,5 @@
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using GLMakie
 using Extents
 using GeoInterface
 
+include("user-agent.jl")
+
 # Default
 @testset "Tiles counts" begin
     london = Rect2f(-0.0921, 51.5, 0.04, 0.025)

--- a/test/user-agent.jl
+++ b/test/user-agent.jl
@@ -1,0 +1,61 @@
+using Test
+using Tyler
+using Sockets
+
+# A minimal, single-request HTTP server that records the request head it receives,
+# so we can check what Tyler actually puts on the wire.
+function capture_request(download)
+    server = Sockets.listen(Sockets.localhost, 0)
+    port = Sockets.getsockname(server)[2]
+    head = String[]
+    serving = @async begin
+        socket = Sockets.accept(server)
+        while true
+            line = readline(socket)
+            isempty(line) && break
+            push!(head, line)
+        end
+        write(socket, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+        close(socket)
+    end
+    try
+        download("http://$(Sockets.localhost):$port/0/0/0")
+        wait(serving)
+    finally
+        close(server)
+    end
+    return head
+end
+
+user_agents(head) = [strip(chopprefix(line, "User-Agent:")) for line in head if startswith(line, "User-Agent:")]
+
+struct UserAgentProvider <: Tyler.TileProviders.AbstractProvider end
+Tyler.file_ending(::UserAgentProvider) = ".png"
+
+@testset "User-Agent" begin
+    @test Tyler.USER_AGENT[] == "Tyler.jl/$(Base.pkgversion(Tyler)) (+https://github.com/MakieOrg/Tyler.jl)"
+
+    @testset "ByteDownloader" begin
+        head = capture_request() do url
+            Tyler.download_tile_data(Tyler.ByteDownloader(), UserAgentProvider(), url)
+        end
+        @test user_agents(head) == [Tyler.USER_AGENT[]]
+    end
+
+    @testset "PathDownloader" begin
+        head = mktempdir() do cache_dir
+            capture_request() do url
+                Tyler.download_tile_data(Tyler.PathDownloader(cache_dir), UserAgentProvider(), url)
+            end
+        end
+        @test user_agents(head) == [Tyler.USER_AGENT[]]
+    end
+
+    @testset "Override" begin
+        agent = "TylerTests/1.0 (+https://github.com/MakieOrg/Tyler.jl)"
+        head = capture_request() do url
+            Tyler.download_tile_data(Tyler.ByteDownloader(; user_agent=agent), UserAgentProvider(), url)
+        end
+        @test user_agents(head) == [agent]
+    end
+end


### PR DESCRIPTION
Fixes #170.

Downloads.jl identifies us as `curl/8.15.0 julia/1.12`, which is exactly the kind of generic default that the [OSM Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) §3.4 blocks ("Traffic that uses these defaults will be blocked because we cannot identify or contact the actual application").

Tile requests now carry a stable `User-Agent` naming Tyler, its version, and a contact URL:

```
User-Agent: Tyler.jl/0.2.6 (+https://github.com/MakieOrg/Tyler.jl)
```

The policy also asks that an SDK "provide a simple override to allow developers to easily identify their app", so applications built on Tyler can name themselves — globally, before creating a `Map`:

```julia
Tyler.USER_AGENT[] = "MyTownMaps/1.4 (+https://mytownmaps.example.com; maps@example.com)"
```

or per downloader, via the new `user_agent` keyword of `ByteDownloader`/`PathDownloader`.

## Implementation notes

- `USER_AGENT[]` is populated in `__init__` alongside `CACHE_PATH`, so it stays correct for relocated/precompiled images.
- The header is passed via the `headers` kwarg of `Downloads.download` rather than `CURLOPT_USERAGENT` in the existing `easy_hook`. That matters: Downloads.jl explicitly `add_header`s its own `User-Agent` whenever `headers` doesn't contain one, and that header wins over `CURLOPT_USERAGENT` — so the `easy_hook` route would have been silently overridden.
- Each downloader stores its header vector rather than rebuilding it per tile, keeping the allocation-conscious style of `download_tile_data`.
- Downloaders read `USER_AGENT[]` at construction, so it must be set before creating a `Map`. This is documented in both the docstring and the guide; happy to read it live per request instead if you'd prefer.

## Testing

`test/user-agent.jl` runs a minimal socket server and asserts on the bytes actually sent, so it fails if the header is dropped or duplicated — covering the default string, both downloaders, and the override:

```
Test Summary: | Pass  Total  Time
User-Agent    |    4      4  0.8s
```

Confirmed on the wire, before → after:

```
User-Agent: curl/8.15.0 julia/1.12
User-Agent: Tyler.jl/0.2.6 (+https://github.com/MakieOrg/Tyler.jl)
```

The rest of `runtests.jl` needs a display and wasn't run locally.

Note this needs a release to reach the users currently being blocked; I left the version bump to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)